### PR TITLE
Bump to 0.5.2b1 and guard AutoInputModel empty inputs

### DIFF
--- a/processingtools/torch_tools/TorchProcess.py
+++ b/processingtools/torch_tools/TorchProcess.py
@@ -395,10 +395,17 @@ class AutoInputModel(torch.nn.Module):
 
         self.get_device(logging)
 
+        if inputs is None:
+            raise ValueError('Inputs cannot be empty.')
+
         if isinstance(inputs, list):
+            if len(inputs) == 0:
+                raise ValueError('Inputs cannot be an empty list.')
             return self._process_batch(inputs, batch_size, num_workers, logging)
 
         if isinstance(inputs, str):
+            if inputs == '':
+                raise ValueError('Input path cannot be an empty string.')
             return self.model(self.image_read(inputs))
 
         raise TypeError('Inputs must be a string or a list of strings')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "processingtools"
-version = "0.5.1b6"
+version = "0.5.2b1"
 description = "A tool for image/video processing"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## Summary
- bump the project version to 0.5.2b1
- raise clear errors when AutoInputModel receives empty inputs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbd22f280c832094197d4bcc84c666